### PR TITLE
feat: fast matcher for common patterns

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Install rust
-        uses: hecrj/setup-rust-action@v1.3.4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          rust-version: 1.55.0
+          rust-version: 1.60.0
           components: clippy,rustfmt
 
       - name: Format

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,5 +1,7 @@
 // Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
+use crate::matcher::InnerMatcher;
+use crate::matcher::Matcher;
 use crate::parser::Options;
 use crate::parser::Part;
 use crate::parser::PartModifier;
@@ -15,6 +17,7 @@ pub(crate) struct Component<R: RegExp> {
   pub pattern_string: String,
   pub regexp: Result<R, Error>,
   pub group_name_list: Vec<String>,
+  pub matcher: Matcher<R>,
 }
 
 impl<R: RegExp> Component<R> {
@@ -32,14 +35,17 @@ impl<R: RegExp> Component<R> {
       &options,
       encoding_callback,
     )?;
+    let part_list = part_list.iter().collect::<Vec<_>>();
     let (regexp_string, name_list) =
       generate_regular_expression_and_name_list(&part_list, &options);
     let regexp = R::parse(&regexp_string).map_err(Error::RegExp);
-    let pattern_string = generate_pattern_string(part_list, &options);
+    let pattern_string = generate_pattern_string(&part_list, &options);
+    let matcher = generate_matcher::<R>(&part_list, &options);
     Ok(Component {
       pattern_string,
       regexp,
       group_name_list: name_list,
+      matcher,
     })
   }
 
@@ -85,7 +91,7 @@ impl<R: RegExp> Component<R> {
 
 // Ref: https://wicg.github.io/urlpattern/#generate-a-regular-expression-and-name-list
 fn generate_regular_expression_and_name_list(
-  part_list: &[Part],
+  part_list: &[&Part],
   options: &Options,
 ) -> (String, Vec<String>) {
   let mut result = String::from("^");
@@ -153,12 +159,15 @@ fn generate_regular_expression_and_name_list(
 }
 
 // Ref: https://wicg.github.io/urlpattern/#generate-a-pattern-string
-fn generate_pattern_string(part_list: Vec<Part>, options: &Options) -> String {
+fn generate_pattern_string(part_list: &[&Part], options: &Options) -> String {
   let mut result = String::new();
   for (i, part) in part_list.iter().enumerate() {
-    let prev_part: Option<&Part> =
-      if i == 0 { None } else { part_list.get(i - 1) };
-    let next_part: Option<&Part> = part_list.get(i + 1);
+    let prev_part: Option<&Part> = if i == 0 {
+      None
+    } else {
+      part_list.get(i - 1).map(|s| *s)
+    };
+    let next_part: Option<&Part> = part_list.get(i + 1).map(|s| *s);
     if part.kind == PartType::FixedText {
       if part.modifier == PartModifier::None {
         result.push_str(&escape_pattern_string(&part.value));
@@ -260,4 +269,93 @@ fn escape_pattern_string(input: &str) -> String {
     result.push(char);
   }
   result
+}
+
+/// This function generates a matcher for a given parts list.
+fn generate_matcher<R: RegExp>(
+  mut part_list: &[&Part],
+  options: &Options,
+) -> Matcher<R> {
+  fn is_literal(part: &Part) -> bool {
+    part.kind == PartType::FixedText && part.modifier == PartModifier::None
+  }
+
+  fn regexp_from_parts<R: RegExp>(
+    part_list: &[&Part],
+    options: &Options,
+  ) -> InnerMatcher<R> {
+    let (regexp_string, _) =
+      generate_regular_expression_and_name_list(&part_list, &options);
+    let regexp = R::parse(&regexp_string).map_err(Error::RegExp);
+    InnerMatcher::RegExp { regexp }
+  }
+
+  // If the first part is a fixed string, we can use it as a literal prefix.
+  let mut prefix = match part_list.first() {
+    Some(part) if is_literal(part) => {
+      part_list = &part_list[1..];
+      part.value.clone()
+    }
+    _ => "".into(),
+  };
+  // If the last part is a fixed string, we can use it as a literal suffix.
+  let mut suffix = match part_list.last() {
+    Some(part) if is_literal(part) => {
+      part_list = &part_list[..part_list.len() - 1];
+      part.value.clone().into()
+    }
+    _ => "".into(),
+  };
+
+  // If there are no more parts, we must have a prefix and/or a suffix. We can
+  // combine these into a single fixed text literal matcher.
+  if part_list.is_empty() {
+    return Matcher::literal(format!("{prefix}{suffix}"));
+  }
+
+  let inner = match part_list {
+    // If there is only one part, and it is a simple full wildcard with no
+    // prefix or suffix, we can use a simple wildcard matcher.
+    [part]
+      if part.kind == PartType::FullWildcard
+        && part.modifier == PartModifier::None =>
+    {
+      prefix += &part.prefix;
+      if !part.suffix.is_empty() {
+        suffix = format!("{}{suffix}", part.suffix);
+      }
+      InnerMatcher::SingleCapture {
+        filter: None,
+        allow_empty: true,
+      }
+    }
+    // If there is only one part, and it is a simple segment wildcard with no
+    // prefix or suffix, we can use a simple wildcard matcher.
+    [part]
+      if part.kind == PartType::SegmentWildcard
+        && part.modifier == PartModifier::None =>
+    {
+      prefix += &part.prefix;
+      if !part.suffix.is_empty() {
+        suffix = format!("{}{suffix}", part.suffix);
+      }
+      let filter = if options.delimiter_code_point.is_empty() {
+        None
+      } else {
+        Some(options.delimiter_code_point.clone())
+      };
+      InnerMatcher::SingleCapture {
+        filter,
+        allow_empty: false,
+      }
+    }
+    // For all other cases, we fall back to a regexp matcher.
+    part_list => regexp_from_parts(part_list, options),
+  };
+
+  Matcher {
+    prefix,
+    suffix,
+    inner,
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod canonicalize_and_process;
 mod component;
 mod constructor_parser;
 mod error;
+mod matcher;
 mod parser;
 pub mod quirks;
 mod regexp;
@@ -405,42 +406,14 @@ impl<R: RegExp> UrlPattern<R> {
       None => return Ok(None),
     };
 
-    let protocol_exec_result = self
-      .protocol
-      .regexp
-      .as_ref()
-      .unwrap()
-      .matches(&input.protocol);
-    let username_exec_result = self
-      .username
-      .regexp
-      .as_ref()
-      .unwrap()
-      .matches(&input.username);
-    let password_exec_result = self
-      .password
-      .regexp
-      .as_ref()
-      .unwrap()
-      .matches(&input.password);
-    let hostname_exec_result = self
-      .hostname
-      .regexp
-      .as_ref()
-      .unwrap()
-      .matches(&input.hostname);
-    let port_exec_result =
-      self.port.regexp.as_ref().unwrap().matches(&input.port);
-    let pathname_exec_result = self
-      .pathname
-      .regexp
-      .as_ref()
-      .unwrap()
-      .matches(&input.pathname);
-    let search_exec_result =
-      self.search.regexp.as_ref().unwrap().matches(&input.search);
-    let hash_exec_result =
-      self.hash.regexp.as_ref().unwrap().matches(&input.hash);
+    let protocol_exec_result = self.protocol.matcher.matches(&input.protocol);
+    let username_exec_result = self.username.matcher.matches(&input.username);
+    let password_exec_result = self.password.matcher.matches(&input.password);
+    let hostname_exec_result = self.hostname.matcher.matches(&input.hostname);
+    let port_exec_result = self.port.matcher.matches(&input.port);
+    let pathname_exec_result = self.pathname.matcher.matches(&input.pathname);
+    let search_exec_result = self.search.matcher.matches(&input.search);
+    let hash_exec_result = self.hash.matcher.matches(&input.hash);
 
     match (
       protocol_exec_result,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -69,7 +69,7 @@ impl<R: RegExp> Matcher<R> {
     }
 
     match &self.inner {
-      InnerMatcher::Literal { literal } => (input == literal).then(|| vec![]),
+      InnerMatcher::Literal { literal } => (input == literal).then(Vec::new),
       InnerMatcher::SingleCapture {
         filter,
         allow_empty,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,0 +1,92 @@
+use crate::regexp::RegExp;
+use crate::Error;
+
+#[derive(Debug)]
+/// A structured representation of a URLPattern matcher, which can be used to
+/// match a URL against a pattern quickly.
+pub(crate) struct Matcher<R: RegExp> {
+  pub prefix: String,
+  pub suffix: String,
+  pub inner: InnerMatcher<R>,
+}
+
+#[derive(Debug)]
+pub(crate) enum InnerMatcher<R: RegExp> {
+  /// A literal string matcher.
+  ///
+  /// # Examples
+  /// - /
+  /// - /foo
+  Literal { literal: String },
+  /// A matcher that matches all chars, except the substring specified in
+  /// `filter` (if it is set).
+  ///
+  /// # Examples
+  /// - *
+  /// - /old/*
+  /// - /scripts/*.js
+  /// - /:slug
+  /// - /blog/:id
+  /// - /blog/:id.html
+  SingleCapture {
+    filter: Option<String>,
+    allow_empty: bool,
+  },
+  /// A regexp matcher. This is a bail-out matcher for arbitrary complexity
+  /// matchers.
+  ///
+  /// # Examples
+  /// - /foo/:id?
+  RegExp { regexp: Result<R, Error> },
+}
+
+impl<R: RegExp> Matcher<R> {
+  pub(crate) fn literal(literal: String) -> Self {
+    Matcher {
+      prefix: "".to_string(),
+      suffix: "".to_string(),
+      inner: InnerMatcher::Literal { literal },
+    }
+  }
+
+  pub fn matches<'a>(&self, mut input: &'a str) -> Option<Vec<&'a str>> {
+    let prefix_len = self.prefix.len();
+    let suffix_len = self.suffix.len();
+    let input_len = input.len();
+    if prefix_len + suffix_len > 0 {
+      // The input must be at least as long as the prefix and suffix combined,
+      // because these must both be present, and not overlap.
+      if input_len < prefix_len + suffix_len {
+        return None;
+      }
+      if !input.starts_with(&self.prefix) {
+        return None;
+      }
+      if !input.ends_with(&self.suffix) {
+        return None;
+      }
+      input = &input[prefix_len..input_len - suffix_len];
+    }
+
+    match &self.inner {
+      InnerMatcher::Literal { literal } => (input == literal).then(|| vec![]),
+      InnerMatcher::SingleCapture {
+        filter,
+        allow_empty,
+      } => {
+        if input.is_empty() && !allow_empty {
+          return None;
+        }
+        if let Some(filter) = filter {
+          if input.contains(filter) {
+            return None;
+          }
+        }
+        Some(vec![input])
+      }
+      InnerMatcher::RegExp { regexp, .. } => {
+        regexp.as_ref().unwrap().matches(input)
+      }
+    }
+  }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,9 +22,9 @@ pub enum RegexSyntax {
 }
 
 // Ref: https://wicg.github.io/urlpattern/#options-header
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Options {
-  delimiter_code_point: String, // TODO: It must contain one ASCII code point or the empty string. maybe Option<char>?
+  pub delimiter_code_point: String, // TODO: It must contain one ASCII code point or the empty string. maybe Option<char>?
   pub prefix_code_point: String, // TODO: It must contain one ASCII code point or the empty string. maybe Option<char>?
   regex_syntax: RegexSyntax,
 }


### PR DESCRIPTION
This commit adds a fast path matcher for common patterns. This fast path
uses literal string comparisons and other simple heurisitics when
possible, but falls back to a full regex match if the simple match
patterns do not suffice (for example when backtracing is necessary).
