### PR TITLE
Use `seek and get the next code point`

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -134,8 +134,7 @@ pub fn tokenize(
   };
 
   while tokenizer.index < tokenizer.input.len() {
-    tokenizer.next_index = tokenizer.index;
-    tokenizer.get_next_codepoint();
+    tokenizer.seek_and_get_next_codepoint(tokenizer.index);
 
     if tokenizer.code_point == Some('*') {
       tokenizer.add_token_with_default_pos_and_len(TokenType::Asterisk);


### PR DESCRIPTION
Hi,

This PR makes the tokenizer implementation closely to the spec.

Ref: https://github.com/WICG/urlpattern/pull/124