### PR TITLE
Embed values in format strings

### DIFF
--- a/src/canonicalize_and_process.rs
+++ b/src/canonicalize_and_process.rs
@@ -13,7 +13,7 @@ pub fn canonicalize_protocol(value: &str) -> Result<String, Error> {
   if value.is_empty() {
     return Ok(String::new());
   }
-  url::Url::parse(&format!("{}://dummy.test", value))
+  url::Url::parse(&format!("{value}://dummy.test"))
     .map(|url| url.scheme().to_owned())
     .map_err(Error::Url)
 }
@@ -92,7 +92,7 @@ pub fn canonicalize_pathname(value: &str) -> Result<String, Error> {
   }
   let leading_slash = value.starts_with('/');
   let modified_value = if !leading_slash {
-    format!("/-{}", value)
+    format!("/-{value}")
   } else {
     value.to_string()
   };

--- a/src/component.rs
+++ b/src/component.rs
@@ -238,7 +238,7 @@ fn generate_pattern_string(part_list: &[&Part], options: &Options) -> String {
         {
           result.push('*');
         } else {
-          result.push_str(&format!("({})", FULL_WILDCARD_REGEXP_VALUE));
+          result.push_str(&format!("({FULL_WILDCARD_REGEXP_VALUE})"));
         }
       }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,10 +13,10 @@ pub enum Error {
   )]
   BaseUrlWithInit,
 
-  #[display(fmt = "tokenizer error: {} (at char {})", _0, _1)]
+  #[display(fmt = "tokenizer error: {_0} (at char {_1})")]
   Tokenizer(TokenizerError, usize),
 
-  #[display(fmt = "parser error: {}", _0)]
+  #[display(fmt = "parser error: {_0}")]
   Parser(ParserError),
 
   Url(url::ParseError),
@@ -39,15 +39,15 @@ pub enum TokenizerError {
   IncompleteEscapeCode,
   #[display(fmt = "invalid name; must be at least length 1")]
   InvalidName,
-  #[display(fmt = "invalid regex: {}", _0)]
+  #[display(fmt = "invalid regex: {_0}")]
   InvalidRegex(&'static str),
 }
 
 #[derive(Debug, Display)]
 pub enum ParserError {
-  #[display(fmt = "expected token {}, found '{}' of type {}", _0, _2, _1)]
+  #[display(fmt = "expected token {_0}, found '{_2}' of type {_1}")]
   ExpectedToken(TokenType, TokenType, String),
 
-  #[display(fmt = "pattern contains duplicate name {}", _0)]
+  #[display(fmt = "pattern contains duplicate name {_0}")]
   DuplicateName(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -592,7 +592,7 @@ mod tests {
     );
 
     if let Some(reason) = case.skip {
-      println!("🟠 Skipping: {}", reason);
+      println!("🟠 Skipping: {reason}");
       return;
     }
 


### PR DESCRIPTION
Hi,

This PR changes to embed values in format strings to fix clippy warnings.

Ref: https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args