### PR TITLE
Improve the delimiter associated with the parser options

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -329,13 +329,8 @@ fn generate_matcher<R: RegExp>(
       if !part.suffix.is_empty() {
         suffix = format!("{}{suffix}", part.suffix);
       }
-      let filter = if options.delimiter_code_point.is_empty() {
-        None
-      } else {
-        Some(options.delimiter_code_point.clone())
-      };
       InnerMatcher::SingleCapture {
-        filter,
+        filter: options.delimiter_code_point,
         allow_empty: false,
       }
     }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -29,7 +29,7 @@ pub(crate) enum InnerMatcher<R: RegExp> {
   /// - /blog/:id
   /// - /blog/:id.html
   SingleCapture {
-    filter: Option<String>,
+    filter: Option<char>,
     allow_empty: bool,
   },
   /// A regexp matcher. This is a bail-out matcher for arbitrary complexity
@@ -78,7 +78,7 @@ impl<R: RegExp> Matcher<R> {
           return None;
         }
         if let Some(filter) = filter {
-          if input.contains(filter) {
+          if input.contains(*filter) {
             return None;
           }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -24,7 +24,7 @@ pub enum RegexSyntax {
 // Ref: https://wicg.github.io/urlpattern/#options-header
 #[derive(Debug, Clone)]
 pub struct Options {
-  pub delimiter_code_point: String, // TODO: It must contain one ASCII code point or the empty string. maybe Option<char>?
+  pub delimiter_code_point: Option<char>,
   pub prefix_code_point: String, // TODO: It must contain one ASCII code point or the empty string. maybe Option<char>?
   regex_syntax: RegexSyntax,
 }
@@ -34,7 +34,7 @@ impl std::default::Default for Options {
   #[inline]
   fn default() -> Self {
     Options {
-      delimiter_code_point: String::new(),
+      delimiter_code_point: None,
       prefix_code_point: String::new(),
       regex_syntax: RegexSyntax::Rust,
     }
@@ -46,7 +46,7 @@ impl Options {
   #[inline]
   pub fn hostname() -> Self {
     Options {
-      delimiter_code_point: String::from("."),
+      delimiter_code_point: Some('.'),
       prefix_code_point: String::new(),
       regex_syntax: RegexSyntax::Rust,
     }
@@ -56,7 +56,7 @@ impl Options {
   #[inline]
   pub fn pathname() -> Self {
     Options {
-      delimiter_code_point: String::from("/"),
+      delimiter_code_point: Some('/'),
       prefix_code_point: String::from("/"),
       regex_syntax: RegexSyntax::Rust,
     }
@@ -99,13 +99,14 @@ impl Options {
     // NOTE: this is a deliberate deviation from the spec. In rust-regex, you
     // can not have a negative character class without specifying any
     // characters.
-    if self.delimiter_code_point.is_empty() {
-      ".+?".to_owned()
-    } else {
+    if let Some(code_point) = self.delimiter_code_point {
+      let mut buffer = [0; 4];
       format!(
         "[^{}]+?",
-        self.escape_regexp_string(&self.delimiter_code_point)
+        self.escape_regexp_string(code_point.encode_utf8(&mut buffer))
       )
+    } else {
+      ".+?".to_owned()
     }
   }
 }

--- a/src/quirks.rs
+++ b/src/quirks.rs
@@ -127,7 +127,7 @@ pub enum InnerMatcher {
   },
   #[serde(rename_all = "camelCase")]
   SingleCapture {
-    filter: Option<String>,
+    filter: Option<char>,
     allow_empty: bool,
   },
   RegExp {


### PR DESCRIPTION
Hi,

This PR changes the type of the delimiter associated with the parser options and resolves the following TODO:

https://github.com/denoland/rust-urlpattern/blob/e65cfc958000744c5127a4450b48d65bf3e7c129/src/parser.rs#L27