### PR TITLE
fix: get codepoint range rather than bytes

### DIFF
--- a/src/constructor_parser.rs
+++ b/src/constructor_parser.rs
@@ -167,11 +167,13 @@ impl<'a> ConstructorStringParser<'a> {
     assert!(self.token_index < self.token_list.len());
     let token = &self.token_list[self.token_index];
     let component_start_index = self.get_safe_token(self.component_start).index;
+
     self
       .input
-      .get(component_start_index..token.index) // TODO: check & codepoint
-      .unwrap()
-      .to_string()
+      .chars()
+      .skip(component_start_index)
+      .take(token.index - component_start_index)
+      .collect()
   }
 
   // Ref: https://wicg.github.io/urlpattern/#rewind-and-set-state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -959,7 +959,8 @@ mod tests {
     quirks::process_construct_pattern_input(
       quirks::StringOrInit::String(":café://:foo".to_owned()),
       None,
-    ).unwrap();
+    )
+    .unwrap();
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,4 +833,12 @@ mod tests {
     })
     .unwrap();
   }
+
+  #[test]
+  fn issue46() {
+    quirks::process_construct_pattern_input(
+      quirks::StringOrInit::String(":café://:foo".to_owned()),
+      None,
+    ).unwrap();
+  }
 }


### PR DESCRIPTION
This addresses the panic mentioned here:

https://github.com/denoland/deno/issues/20906
https://github.com/denoland/rust-urlpattern/issues/46

I don't know if some additional tests might be warranted here?