### PR TITLE
fixed quirks::parse_pattern of WPT  [{ "pathname": "/(\\m)" }]

### DIFF
--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -5,7 +5,7 @@ pub trait RegExp: Sized {
 
   /// Generates a regexp pattern for the given string. If the pattern is
   /// invalid, the parse function should return an error.
-  fn parse(pattern: &str, flags: &str) -> Result<Self, ()>;
+  fn parse(pattern: &str, flags: &str, force_eval: bool) -> Result<Self, ()>;
 
   /// Matches the given text against the regular expression and returns the list
   /// of captures. The matches are returned in the order they appear in the
@@ -22,7 +22,7 @@ impl RegExp for regex::Regex {
     RegexSyntax::Rust
   }
 
-  fn parse(pattern: &str, flags: &str) -> Result<Self, ()> {
+  fn parse(pattern: &str, flags: &str, _force_eval: bool) -> Result<Self, ()> {
     regex::Regex::new(&format!("(?{flags}){pattern}")).map_err(|_| ())
   }
 


### PR DESCRIPTION
URLPattern crate doesn't seem to test for `quirks::parse_pattern` but one of the failing tests when invoked from firefox 

```
{
    "pattern": [{ "pathname": "/(\\m)" }],
    "expected_obj": "error"
  },
```

Relevant spec location: https://urlpattern.spec.whatwg.org/#compile-a-component
I'm not seeing the place in the algorithm where we should explicitly run the parser eval, but the spec notes the following:
"
The specification uses regular expressions to perform all matching, but this is not mandated. Implementations are free to perform matching directly against the [part list](https://urlpattern.spec.whatwg.org/#part-list) when possible; e.g. when there are no custom regexp matching groups. If there are custom regular expressions, however, its important that they be immediately evaluated in the [compile a component](https://urlpattern.spec.whatwg.org/#compile-a-component) algorithm so an error can be thrown if they are invalid.
"

This is a bit of a hack and probably we should just be feeding Spidermonkey regex into the pattern, but it seems to fix the test without breaking anything else.