### PR TITLE
chore: use icu_properties instead of unic-ucd-ident

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 url = "2.5.6"
 regex = "1.10.5"
 serde = { version = "1.0.127", features = ["derive"] }
-unic-ucd-ident = { version = "0.9.0", features = ["id"] }
+icu_properties = "2"
 
 [dev-dependencies]
 serde_json = "1.0.66"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1064,6 +1064,22 @@ mod tests {
   }
 
   #[test]
+  fn issue54() {
+    let pattern = <UrlPattern>::parse(
+      UrlPatternInit {
+        pathname: Some("/:thereisa\u{30FB}middledot.".to_owned()),
+        ..Default::default()
+      },
+      Default::default(),
+    )
+    .unwrap();
+    assert_eq!(
+      pattern.pathname.group_name_list,
+      vec!["thereisa\u{30FB}middledot"]
+    );
+  }
+
+  #[test]
   fn issue61() {
     // Test case for https://github.com/denoland/deno/issues/29935
     // Custom protocols should not escape colons and slashes in pattern pathnames

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -2,6 +2,10 @@
 
 use crate::error::TokenizerError;
 use crate::Error;
+use icu_properties::{
+  props::{IdContinue, IdStart},
+  CodePointSetDataBorrowed,
+};
 
 // Ref: https://wicg.github.io/urlpattern/#tokens
 // Ref: https://wicg.github.io/urlpattern/#tokenizing
@@ -323,13 +327,18 @@ pub fn tokenize(
   Ok(tokenizer.token_list)
 }
 
+static ID_START: CodePointSetDataBorrowed<'_> =
+  CodePointSetDataBorrowed::new::<IdStart>();
+static ID_CONTINUE: CodePointSetDataBorrowed<'_> =
+  CodePointSetDataBorrowed::new::<IdContinue>();
+
 // Ref: https://wicg.github.io/urlpattern/#is-a-valid-name-code-point
 #[inline]
 pub(crate) fn is_valid_name_codepoint(code_point: char, first: bool) -> bool {
   if first {
-    unic_ucd_ident::is_id_start(code_point) || matches!(code_point, '$' | '_')
+    ID_START.contains(code_point) || matches!(code_point, '$' | '_')
   } else {
-    unic_ucd_ident::is_id_continue(code_point)
+    ID_CONTINUE.contains(code_point)
       || matches!(code_point, '$' | '\u{200C}' | '\u{200D}')
   }
 }


### PR DESCRIPTION
Fixes #54. This is an alternative to #56. In the default config the `url` crate also depends on the `icu_properties` crate. (As suggested by @makotokato)