### PR TITLE
Fixed issue 78: byte index 2 is out-of-bounds in canonicalize_and_process

### DIFF
--- a/src/canonicalize_and_process.rs
+++ b/src/canonicalize_and_process.rs
@@ -98,7 +98,11 @@ pub fn canonicalize_pathname(value: &str) -> Result<String, Error> {
   let mut url = url::Url::parse("http://dummy.test").unwrap();
   url.set_path(&modified_value);
   let mut pathname = url::quirks::pathname(&url);
-  if !leading_slash {
+
+  // If the original value didn't have a leading slash, we prepended "/-".
+  // Only strip this prefix if it's still there after URL parsing.
+  // If the ".." segments were resolved, the "/-" prefix may have been removed.
+  if !leading_slash && pathname.starts_with("/-") {
     pathname = &pathname[2..];
   }
   Ok(pathname.to_string())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1132,4 +1132,10 @@ mod tests {
     )
     .unwrap();
   }
+
+  #[test]
+  fn issue78() {
+    use crate::canonicalize_and_process::canonicalize_pathname;
+    assert!(canonicalize_pathname("3�/..").is_ok());
+  }
 }


### PR DESCRIPTION
  If the original value didn't have a leading slash, we prepended "/-".
  Only strip this prefix if it's still there after URL parsing.
  If the ".." segments were resolved, the "/-" prefix may have been removed