### PR TITLE
extended support for browser-supplied regex parser 

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -16,7 +16,7 @@ use std::fmt::Write;
 
 // Ref: https://wicg.github.io/urlpattern/#component
 #[derive(Debug)]
-pub(crate) struct Component<R: RegExp> {
+pub struct Component<R: RegExp> {
   pub pattern_string: String,
   pub regexp: Result<R, Error>,
   pub group_name_list: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,13 @@
 //! For a usage example, see the [UrlPattern] documentation.
 
 mod canonicalize_and_process;
-mod component;
+pub mod component;
 mod constructor_parser;
 mod error;
-mod matcher;
-mod parser;
+pub mod matcher;
+pub mod parser;
 pub mod quirks;
-mod regexp;
+pub mod regexp;
 mod tokenizer;
 
 pub use error::Error;
@@ -27,10 +27,14 @@ use crate::canonicalize_and_process::ProcessType;
 use crate::component::Component;
 use crate::regexp::RegExp;
 
+pub use parser::RegexSyntax;
+
 /// Options to create a URL pattern.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UrlPatternOptions {
+  #[serde(default)]
+  pub regex_syntax: RegexSyntax,
   pub ignore_case: bool,
 }
 
@@ -284,14 +288,14 @@ fn is_absolute_pathname(
 /// ```
 #[derive(Debug)]
 pub struct UrlPattern<R: RegExp = regex::Regex> {
-  protocol: Component<R>,
-  username: Component<R>,
-  password: Component<R>,
-  hostname: Component<R>,
-  port: Component<R>,
-  pathname: Component<R>,
-  search: Component<R>,
-  hash: Component<R>,
+  pub protocol: Component<R>,
+  pub username: Component<R>,
+  pub password: Component<R>,
+  pub hostname: Component<R>,
+  pub port: Component<R>,
+  pub pathname: Component<R>,
+  pub search: Component<R>,
+  pub hash: Component<R>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -340,7 +344,10 @@ impl<R: RegExp> UrlPattern<R> {
     let protocol = Component::compile(
       processed_init.protocol.as_deref(),
       canonicalize_and_process::canonicalize_protocol,
-      parser::Options::default(),
+      parser::Options {
+        regex_syntax: options.regex_syntax,
+        ..parser::Options::default()
+      },
     )?
     .optionally_transpose_regex_error(report_regex_errors)?;
 
@@ -354,20 +361,27 @@ impl<R: RegExp> UrlPattern<R> {
       Component::compile(
         processed_init.hostname.as_deref(),
         canonicalize_and_process::canonicalize_ipv6_hostname,
-        parser::Options::hostname(),
+        parser::Options {
+          regex_syntax: options.regex_syntax,
+          ..parser::Options::hostname()
+        },
       )?
       .optionally_transpose_regex_error(report_regex_errors)?
     } else {
       Component::compile(
         processed_init.hostname.as_deref(),
         canonicalize_and_process::canonicalize_hostname,
-        parser::Options::hostname(),
+        parser::Options {
+          regex_syntax: options.regex_syntax,
+          ..parser::Options::hostname()
+        },
       )?
       .optionally_transpose_regex_error(report_regex_errors)?
     };
 
     let compile_options = parser::Options {
       ignore_case: options.ignore_case,
+      regex_syntax: options.regex_syntax,
       ..Default::default()
     };
 
@@ -391,6 +405,7 @@ impl<R: RegExp> UrlPattern<R> {
           canonicalize_and_process::canonicalize_pathname,
           parser::Options {
             ignore_case: options.ignore_case,
+            regex_syntax: options.regex_syntax,
             ..parser::Options::pathname()
           },
         )?
@@ -410,20 +425,29 @@ impl<R: RegExp> UrlPattern<R> {
       username: Component::compile(
         processed_init.username.as_deref(),
         canonicalize_and_process::canonicalize_username,
-        parser::Options::default(),
+        parser::Options {
+          regex_syntax: options.regex_syntax,
+          ..parser::Options::default()
+        },
       )?
       .optionally_transpose_regex_error(report_regex_errors)?,
       password: Component::compile(
         processed_init.password.as_deref(),
         canonicalize_and_process::canonicalize_password,
-        parser::Options::default(),
+        parser::Options {
+          regex_syntax: options.regex_syntax,
+          ..parser::Options::default()
+        },
       )?
       .optionally_transpose_regex_error(report_regex_errors)?,
       hostname,
       port: Component::compile(
         processed_init.port.as_deref(),
         |port| canonicalize_and_process::canonicalize_port(port, None),
-        parser::Options::default(),
+        parser::Options {
+          regex_syntax: options.regex_syntax,
+          ..parser::Options::default()
+        },
       )?
       .optionally_transpose_regex_error(report_regex_errors)?,
       pathname,

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -4,7 +4,7 @@ use crate::Error;
 #[derive(Debug)]
 /// A structured representation of a URLPattern matcher, which can be used to
 /// match a URL against a pattern quickly.
-pub(crate) struct Matcher<R: RegExp> {
+pub struct Matcher<R: RegExp> {
   pub prefix: String,
   pub suffix: String,
   pub inner: InnerMatcher<R>,
@@ -12,7 +12,7 @@ pub(crate) struct Matcher<R: RegExp> {
 }
 
 #[derive(Debug)]
-pub(crate) enum InnerMatcher<R: RegExp> {
+pub enum InnerMatcher<R: RegExp> {
   /// A literal string matcher.
   ///
   /// # Examples

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,13 +5,19 @@ use crate::tokenizer::Token;
 use crate::tokenizer::TokenType;
 use crate::Error;
 
+use serde::Deserialize;
+use serde::Serialize;
+
 // Ref: https://wicg.github.io/urlpattern/#full-wildcard-regexp-value
 pub const FULL_WILDCARD_REGEXP_VALUE: &str = ".*";
 
 /// The regexp syntax that should be used.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(
+  Default, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize,
+)]
 pub enum RegexSyntax {
   /// Compile regexes to rust-regex syntax. This is the default.
+  #[default]
   Rust,
   /// Compile regexes to ECMAScript syntax. This should be used with the
   /// [crate::quirks::component_regex].

--- a/src/quirks.rs
+++ b/src/quirks.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use url::Url;
 
-use crate::component::Component;
+pub use crate::component::Component;
 use crate::parser::RegexSyntax;
 use crate::regexp::RegExp;
 pub use crate::Error;
@@ -102,11 +102,15 @@ pub struct UrlPatternComponent {
   pub group_name_list: Vec<String>,
 }
 
-impl From<Component<EcmaRegexp>> for UrlPatternComponent {
-  fn from(component: Component<EcmaRegexp>) -> Self {
+impl<R: RegExp> From<Component<R>> for UrlPatternComponent {
+  fn from(component: Component<R>) -> Self {
+    let regexp_string = component
+      .regexp
+      .map(|r| r.pattern_string())
+      .unwrap_or_default();
     Self {
       pattern_string: component.pattern_string,
-      regexp_string: component.regexp.unwrap().0,
+      regexp_string,
       matcher: component.matcher.into(),
       group_name_list: component.group_name_list,
     }
@@ -138,8 +142,8 @@ pub enum InnerMatcher {
   },
 }
 
-impl From<crate::matcher::Matcher<EcmaRegexp>> for Matcher {
-  fn from(matcher: crate::matcher::Matcher<EcmaRegexp>) -> Self {
+impl<R: RegExp> From<crate::matcher::Matcher<R>> for Matcher {
+  fn from(matcher: crate::matcher::Matcher<R>) -> Self {
     Self {
       prefix: matcher.prefix,
       suffix: matcher.suffix,
@@ -148,8 +152,8 @@ impl From<crate::matcher::Matcher<EcmaRegexp>> for Matcher {
   }
 }
 
-impl From<crate::matcher::InnerMatcher<EcmaRegexp>> for InnerMatcher {
-  fn from(inner: crate::matcher::InnerMatcher<EcmaRegexp>) -> Self {
+impl<R: RegExp> From<crate::matcher::InnerMatcher<R>> for InnerMatcher {
+  fn from(inner: crate::matcher::InnerMatcher<R>) -> Self {
     match inner {
       crate::matcher::InnerMatcher::Literal { literal } => {
         Self::Literal { literal }
@@ -162,13 +166,13 @@ impl From<crate::matcher::InnerMatcher<EcmaRegexp>> for InnerMatcher {
         allow_empty,
       },
       crate::matcher::InnerMatcher::RegExp { regexp } => Self::RegExp {
-        regexp: regexp.unwrap().0,
+        regexp: regexp.map(|r| r.pattern_string()).unwrap_or_default(),
       },
     }
   }
 }
 
-struct EcmaRegexp(String, String);
+pub struct EcmaRegexp(String, String);
 
 impl RegExp for EcmaRegexp {
   fn syntax() -> RegexSyntax {
@@ -191,15 +195,18 @@ impl RegExp for EcmaRegexp {
     let regexp = regex::Regex::parse(&self.0, &self.1, false).ok()?;
     regexp.matches(text)
   }
+
+  fn pattern_string(&self) -> String {
+    self.0.clone()
+  }
 }
 
 /// Parse a pattern into its components.
-pub fn parse_pattern(
+pub fn parse_pattern<R: RegExp>(
   init: crate::UrlPatternInit,
   options: UrlPatternOptions,
 ) -> Result<UrlPattern, Error> {
-  let pattern =
-    crate::UrlPattern::<EcmaRegexp>::parse_internal(init, true, options)?;
+  let pattern = crate::UrlPattern::<R>::parse_internal(init, true, options)?;
 
   let urlpattern = UrlPattern {
     has_regexp_groups: pattern.has_regexp_groups(),
@@ -213,6 +220,14 @@ pub fn parse_pattern(
     hash: pattern.hash.into(),
   };
   Ok(urlpattern)
+}
+
+pub fn parse_pattern_as_lib<R: RegExp>(
+  init: crate::UrlPatternInit,
+  options: UrlPatternOptions,
+) -> Result<crate::UrlPattern<R>, Error> {
+  let pattern = crate::UrlPattern::<R>::parse_internal(init, true, options)?;
+  Ok(pattern)
 }
 
 pub type Inputs = (StringOrInit, Option<String>);

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -5,6 +5,7 @@ pub trait RegExp: Sized {
 
   /// Generates a regexp pattern for the given string. If the pattern is
   /// invalid, the parse function should return an error.
+  #[allow(clippy::result_unit_err)]
   fn parse(pattern: &str, flags: &str, force_eval: bool) -> Result<Self, ()>;
 
   /// Matches the given text against the regular expression and returns the list
@@ -15,6 +16,8 @@ pub trait RegExp: Sized {
   ///
   /// Returns `None` if the text does not match the regular expression.
   fn matches<'a>(&self, text: &'a str) -> Option<Vec<Option<&'a str>>>;
+
+  fn pattern_string(&self) -> String;
 }
 
 impl RegExp for regex::Regex {
@@ -36,5 +39,9 @@ impl RegExp for regex::Regex {
       .collect();
 
     Some(captures)
+  }
+
+  fn pattern_string(&self) -> String {
+    self.as_str().to_string()
   }
 }


### PR DESCRIPTION
exposed some lib.rs and internal classes to simplify browser-side bindings to work with the crate.
Also Regexp choice was getting dropped by component compilation so now options use the specified regex syntax and pass those into each component correctly