### PR TITLE
moved unnecessary copy of StringOrInit up into the test layer

### DIFF
--- a/benches/parse_patterns.rs
+++ b/benches/parse_patterns.rs
@@ -6,7 +6,7 @@ fn bench_parse_shipping_groups_summary(c: &mut Criterion) {
     b.iter(|| {
       let input = quirks::process_construct_pattern_input(
         black_box(quirks::StringOrInit::String(
-          "component-ShippingGroupsSummary.*.js".to_owned(),
+          "component-ShippingGroupsSummary.*.js".into(),
         )),
         black_box(Some("https://example.test/web/")),
       );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -659,10 +659,11 @@ mod tests {
 
   #[derive(Debug, Deserialize)]
   #[serde(untagged)]
+  #[serde(bound(deserialize = "'de: 'a"))]
   #[allow(clippy::large_enum_variant)]
-  enum ExpectedMatch {
+  enum ExpectedMatch<'a> {
     String(String),
-    MatchResult(MatchResult),
+    MatchResult(MatchResult<'a>),
   }
 
   #[derive(Debug, Deserialize)]
@@ -674,28 +675,30 @@ mod tests {
   #[allow(clippy::large_enum_variant)]
   #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
   #[serde(untagged)]
-  pub enum StringOrInitOrOptions {
+  pub enum StringOrInitOrOptions<'a> {
     Options(UrlPatternOptions),
-    StringOrInit(quirks::StringOrInit),
+    StringOrInit(quirks::StringOrInit<'a>),
   }
 
   #[derive(Debug, Deserialize)]
-  struct TestCase {
+  #[serde(bound(deserialize = "'de: 'a"))]
+  struct TestCase<'a> {
     skip: Option<String>,
-    pattern: Vec<StringOrInitOrOptions>,
+    pattern: Vec<StringOrInitOrOptions<'a>>,
     #[serde(default)]
-    inputs: Vec<quirks::StringOrInit>,
-    expected_obj: Option<quirks::StringOrInit>,
-    expected_match: Option<ExpectedMatch>,
+    inputs: Vec<quirks::StringOrInit<'a>>,
+    expected_obj: Option<quirks::StringOrInit<'a>>,
+    expected_match: Option<ExpectedMatch<'a>>,
     #[serde(default)]
     exactly_empty_components: Vec<String>,
   }
 
   #[derive(Debug, Deserialize)]
-  struct MatchResult {
+  #[serde(bound(deserialize = "'de: 'a"))]
+  struct MatchResult<'a> {
     #[serde(deserialize_with = "deserialize_match_result_inputs")]
     #[serde(default)]
-    inputs: Option<(quirks::StringOrInit, Option<String>)>,
+    inputs: Option<(quirks::StringOrInit<'a>, Option<String>)>,
 
     protocol: Option<ComponentResult>,
     username: Option<ComponentResult>,
@@ -707,17 +710,17 @@ mod tests {
     hash: Option<ComponentResult>,
   }
 
-  fn deserialize_match_result_inputs<'de, D>(
+  fn deserialize_match_result_inputs<'a, D>(
     deserializer: D,
-  ) -> Result<Option<(quirks::StringOrInit, Option<String>)>, D::Error>
+  ) -> Result<Option<(quirks::StringOrInit<'a>, Option<String>)>, D::Error>
   where
-    D: serde::Deserializer<'de>,
+    D: serde::Deserializer<'a>,
   {
     #[derive(Debug, Deserialize)]
     #[serde(untagged)]
-    enum MatchResultInputs {
-      OneArgument((quirks::StringOrInit,)),
-      TwoArguments(quirks::StringOrInit, String),
+    enum MatchResultInputs<'a> {
+      OneArgument((quirks::StringOrInit<'a>,)),
+      TwoArguments(quirks::StringOrInit<'a>, String),
     }
 
     let res = Option::<MatchResultInputs>::deserialize(deserializer)?;
@@ -811,7 +814,7 @@ mod tests {
       ..
     }) = &input
     {
-      base_url = Some(url.clone())
+      base_url = Some(url.clone().into())
     }
 
     macro_rules! assert_field {
@@ -921,7 +924,8 @@ mod tests {
 
     let input = input.unwrap_or_else(|| StringOrInit::Init(Default::default()));
 
-    let expected_input = (input.clone(), base_url.clone());
+    let expected_input =
+      (input.clone(), base_url.clone().map(|s| s.to_string()));
 
     let match_input = quirks::process_match_input(input, base_url.as_deref());
 
@@ -1058,7 +1062,7 @@ mod tests {
   #[test]
   fn issue46() {
     quirks::process_construct_pattern_input(
-      quirks::StringOrInit::String(":café://:foo".to_owned()),
+      quirks::StringOrInit::String(":café://:foo".to_owned().into()),
       None,
     )
     .unwrap();

--- a/src/regexp.rs
+++ b/src/regexp.rs
@@ -17,7 +17,7 @@ pub trait RegExp: Sized {
   /// Returns `None` if the text does not match the regular expression.
   fn matches<'a>(&self, text: &'a str) -> Option<Vec<Option<&'a str>>>;
 
-  fn pattern_string(&self) -> String;
+  fn pattern_string(&self) -> &str;
 }
 
 impl RegExp for regex::Regex {
@@ -41,7 +41,7 @@ impl RegExp for regex::Regex {
     Some(captures)
   }
 
-  fn pattern_string(&self) -> String {
-    self.as_str().to_string()
+  fn pattern_string(&self) -> &str {
+    self.as_str()
   }
 }


### PR DESCRIPTION
Make StringOrInit use COW for string variant to avoid a copy when calling
quirks::process_match_input